### PR TITLE
[Feat] 턴제 배틀 구현

### DIFF
--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -149,9 +149,26 @@ void GameManager::SaveTurn()
 	BattleTurnInfos.push_back(TurnInfo);
 }
 
+// 다음 배틀턴을 설정합니다.
 void GameManager::NextTurn()
 {
-
+	// 몬스터 체력이 없을 경우, 플레이어 승리 및 턴 종료 
+	if (BattleMonster->GetHealth() <= 0)
+	{
+		BattleResult = EBattleResult::PlayerWin;
+		BattleTurn = EBattleTurn::End;
+	}
+	// 플레이어 체력이 없을 경우, 몬스터 승리 및 턴 종료 
+	else if (BattlePlayer->GetHealth() <= 0)
+	{
+		BattleResult = EBattleResult::MonsterWin;
+		BattleTurn = EBattleTurn::End;
+	}
+	else
+	{
+		// 승자가 없을 경우 다음 턴을 계산합니다. (PlayerTurn -> MonsterTurn, MonsterTurn -> PlayerTurn)
+		BattleTurn = static_cast<EBattleTurn>((static_cast<int>(BattleTurn) + 1) % static_cast<int>(EBattleTurn::End));
+	}
 }
 
 Monster* GameManager::CreateBattleMonster(int PlayerLevel)

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -107,6 +107,9 @@ void GameManager::InitBattle(Character* Player)
 
 void GameManager::StartBattle()
 {
+	// 배틀 시작 시, 초기 플레이어와 몬스터의 정보를 저장합니다.
+	SaveTurn();
+
 	while (BattleTurn != EBattleTurn::End)
 	{
 		PlayTurn();
@@ -117,6 +120,8 @@ void GameManager::StartBattle()
 
 void GameManager::EndBattle()
 {
+	// 배틀 종료 후, 턴별 배틀 정보를 출력합니다.
+	DisplayBattleInfos();
 }
 
 void GameManager::PlayTurn()
@@ -196,6 +201,62 @@ void GameManager::TargetAttack(Character* Attacker, Monster* Defender)
 {
 	// 플레이어 공격, 몬스터의 HP를 수정합니다
 	Defender->TakeDamage(Attacker->GetAttack());
+}
+
+void GameManager::DisplayBattleInfos()
+{
+	// 턴 정보를 화면에 출력하기 위해 최소 2개가 필요합니다.
+	// [0] 배틀 시작시 초기 플레이어와 몬스터 정보
+	// [1] 배틀 시작후 1턴 이상의 전투 정보
+	static const int MIN_TURN_IDX = 2;
+
+ 	if (BattleTurnInfos.size() <= MIN_TURN_IDX)
+		return;
+
+	for (int TurnIdx = 1; TurnIdx < BattleTurnInfos.size(); ++TurnIdx)
+	{
+		FBattleTurnInfo& PrevInfo = BattleTurnInfos[TurnIdx - 1];
+		FBattleTurnInfo& CurInfo = BattleTurnInfos[TurnIdx];
+
+		DisplayBattleInfo(PrevInfo, CurInfo, TurnIdx);
+	}
+}
+
+
+void GameManager::DisplayBattleInfo(const FBattleTurnInfo& PrevInfo, const FBattleTurnInfo& CurInfo, int TurnIdx)
+{
+	// 첫 턴에는 몬스터의 정보를 출력합니다.
+	if (TurnIdx == 1)
+	{
+		std::cout << "몬스터" << BattlePlayer->GetName() << " 등장! 체력: " << PrevInfo.MonsterHP << ", 공격력: " << PrevInfo.MonsterAttack << std::endl;
+		return;
+	}
+
+	switch (CurInfo.BattleTurn)
+	{
+		case EBattleTurn::PlayerTurn:
+			if (CurInfo.MonsterHP > 0)
+			{
+				std::cout << "" << BattlePlayer->GetName() << "이(가) " << BattleMonster->GetName() << "을(를) 공격합니다! " << BattleMonster->GetName() << " 체력: " << CurInfo.MonsterHP << std::endl;
+			}
+			else
+				{
+			std::cout << "" << BattlePlayer->GetName() << "이(가) " << BattleMonster->GetName() << "을(를) 공격합니다! " << BattleMonster->GetName() << " 처치!" << std::endl;
+			}
+			break;
+		case EBattleTurn::MonsterTurn:
+			if (CurInfo.PlayerHP > 0)
+			{
+				std::cout << "" << BattleMonster->GetName() << "이(가) " << BattlePlayer->GetName() << "을(를) 공격합니다!" << BattlePlayer->GetName() << "체력: " << CurInfo.PlayerHP << " / " << BattlePlayer->GetMaxHealth() << std::endl;
+			}
+			else
+				{
+			std::cout << "" << BattleMonster->GetName() << "이(가) " << BattlePlayer->GetName() << "을(를) 공격합니다!" << BattlePlayer->GetName() << "체력: " << PrevInfo.PlayerHP << "->" << CurInfo.PlayerHP << std::endl;
+			}
+			break;
+		default:
+			break;
+	}
 }
 
 void GameManager::TargetAttack(Monster* Attacker, Character* Defender)

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -15,7 +15,10 @@ GameManager::GameManager()
 
 GameManager::~GameManager()
 {
-
+	if (!BattleMonster)
+	{
+		delete BattleMonster;
+	}
 }
 
 void GameManager::Init()

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -39,17 +39,17 @@ Monster* GameManager::GenerateMonster(int Level)
 	Monster* CreatedMonster = nullptr;
 	switch (RandNumber)
 	{
-	case 0:
-		CreatedMonster = new Orc(Level);
-		break;
-	case 1:
-		CreatedMonster = new Troll(Level);
-		break;
-	case 2:
-		CreatedMonster = new Goblin(Level);
-		break;
-	default:
-		break;
+		case 0:
+			CreatedMonster = new Orc(Level);
+			break;
+		case 1:
+			CreatedMonster = new Troll(Level);
+			break;
+		case 2:
+			CreatedMonster = new Goblin(Level);
+			break;
+		default:
+			break;
 	}
 
 	return CreatedMonster;
@@ -98,9 +98,9 @@ void GameManager::InitBattle(Character* Player)
 	if (Player)
 	{
 		BattleMonster = CreateBattleMonster(Player->GetLevel());
+		// 플레이어가 유효할 경우 배틀 플레이어를 설정합니다.
+		BattlePlayer = Player;
 	}
-
-	BattlePlayer = Player;
 
 	// 플레이어 턴 초기화
 	BattleTurn = EBattleTurn::PlayerTurn;

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -19,6 +19,8 @@ GameManager::~GameManager()
 	{
 		delete BattleMonster;
 	}
+
+	BattleTurnInfos.clear();
 }
 
 void GameManager::Init()
@@ -100,6 +102,7 @@ void GameManager::InitBattle(Character* Player)
 
 	// 플레이어 턴 초기화
 	BattleTurn = EBattleTurn::PlayerTurn;
+	BattleTurnInfos.clear();
 }
 
 void GameManager::StartBattle()
@@ -132,10 +135,18 @@ void GameManager::PlayTurn()
 	}
 }
 
-// 전투 처리와 화면 출력을 분리하고픈 마음에 턴 별 데이터를 저장합니다
+// 전투 처리와 화면 출력을 분리하고픈 마음에 턴별 데이터를 저장합니다
 void GameManager::SaveTurn()
 {
+	// 화면 출력에 필요한 데이터를 저장합니다.
+	FBattleTurnInfo TurnInfo;
+	TurnInfo.MonsterHP = BattleMonster->GetHealth();
+	TurnInfo.MonsterAttack = BattleMonster->GetAttack();
+	TurnInfo.PlayerHP = BattlePlayer->GetHealth();
+	TurnInfo.PlayerAttack = BattlePlayer->GetAttack();
+	TurnInfo.BattleTurn = BattleTurn;
 
+	BattleTurnInfos.push_back(TurnInfo);
 }
 
 void GameManager::NextTurn()

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -97,6 +97,9 @@ void GameManager::InitBattle(Character* Player)
 	}
 
 	BattlePlayer = Player;
+
+	// 플레이어 턴 초기화
+	BattleTurn = EBattleTurn::PlayerTurn;
 }
 
 void GameManager::StartBattle()
@@ -129,6 +132,7 @@ void GameManager::PlayTurn()
 	}
 }
 
+// 전투 처리와 화면 출력을 분리하고픈 마음에 턴 별 데이터를 저장합니다
 void GameManager::SaveTurn()
 {
 

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -54,8 +54,32 @@ BossMonster* GameManager::GenerateBossMonster(int Level)
 
 void GameManager::Battle(Character* Player)
 {
+	InitBattle(Player);
 
+	if (CanBattle() == false)
+		return;
+
+	StartBattle();
+	EndBattle();
 }
+
+bool GameManager::CanBattle()
+{
+	return false;
+}
+
+void GameManager::InitBattle(Character* Player)
+{
+}
+
+void GameManager::StartBattle()
+{
+}
+
+void GameManager::EndBattle()
+{
+}
+
 
 void GameManager::VisitShop(Character* Player)
 {

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -8,6 +8,7 @@
 #include <time.h>
 
 GameManager::GameManager()
+: BattlePlayer(nullptr), BattleMonster(nullptr)
 {
     Init();
 }
@@ -70,16 +71,43 @@ bool GameManager::CanBattle()
 
 void GameManager::InitBattle(Character* Player)
 {
+	if (BattleMonster)
+	{
+		delete BattleMonster;
+		BattleMonster = nullptr;
+	}
+
+	if (Player)
+	{
+		BattleMonster = CreateBattleMonster(Player->GetLevel());
+	}
+
+	BattlePlayer = Player;
 }
 
 void GameManager::StartBattle()
 {
+
 }
 
 void GameManager::EndBattle()
 {
 }
 
+Monster* GameManager::CreateBattleMonster(int PlayerLevel)
+{
+	Monster* CreatedMonster = nullptr;
+	if (PlayerLevel >= 10)
+	{
+		CreatedMonster = GenerateBossMonster(PlayerLevel);
+	}
+	else
+	{
+		CreatedMonster = GenerateMonster(PlayerLevel);
+	}
+
+	return CreatedMonster;
+}
 
 void GameManager::VisitShop(Character* Player)
 {

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -101,11 +101,31 @@ void GameManager::InitBattle(Character* Player)
 
 void GameManager::StartBattle()
 {
-
+	while (BattleTurn != EBattleTurn::End)
+	{
+		PlayTurn();
+		SaveTurn();
+		NextTurn();
+	}
 }
 
 void GameManager::EndBattle()
 {
+}
+
+void GameManager::PlayTurn()
+{
+
+}
+
+void GameManager::SaveTurn()
+{
+
+}
+
+void GameManager::NextTurn()
+{
+
 }
 
 Monster* GameManager::CreateBattleMonster(int PlayerLevel)

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -115,7 +115,18 @@ void GameManager::EndBattle()
 
 void GameManager::PlayTurn()
 {
-
+	switch (BattleTurn)
+	{
+	case EBattleTurn::PlayerTurn:
+		TryUsePotion();
+		TargetAttack(BattlePlayer, BattleMonster);
+		break;
+	case EBattleTurn::MonsterTurn:
+		TargetAttack(BattleMonster, BattlePlayer);
+		break;
+	default:
+		break;
+	}
 }
 
 void GameManager::SaveTurn()
@@ -141,6 +152,25 @@ Monster* GameManager::CreateBattleMonster(int PlayerLevel)
 	}
 
 	return CreatedMonster;
+}
+
+/* TODO: 전투 중 포션 사용 */
+void GameManager::TryUsePotion()
+{
+
+}
+
+void GameManager::TargetAttack(Character* Attacker, Monster* Defender)
+{
+	// 플레이어 공격, 몬스터의 HP를 수정합니다
+	Defender->TakeDamage(Attacker->GetAttack());
+}
+
+void GameManager::TargetAttack(Monster* Attacker, Character* Defender)
+{
+	// 몬스터 공격, 플레이어의 HP를 수정합니다
+	int CurrentHealth = std::max(0, Defender->GetHealth() - Attacker->GetAttack());
+	Defender->SetHealth(CurrentHealth);
 }
 
 void GameManager::VisitShop(Character* Player)

--- a/Manager/GameManager.cpp
+++ b/Manager/GameManager.cpp
@@ -69,7 +69,18 @@ void GameManager::Battle(Character* Player)
 
 bool GameManager::CanBattle()
 {
-	return false;
+	if (BattleMonster == nullptr)
+	{
+		std::cout << "배틀 몬스터가 존재하지 않습니다!" << std::endl;
+		return false;
+	}
+	if (BattlePlayer == nullptr)
+	{
+		std::cout << "현재 배틀에 참여한 플레이어가 없습니다!" << std::endl;
+		return false;
+	}
+
+	return true;
 }
 
 void GameManager::InitBattle(Character* Player)

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -41,6 +41,10 @@ private:
 
 	Monster* CreateBattleMonster(int PlayerLevel);
 
+	void TryUsePotion();
+	void TargetAttack(Monster* Attacker, Character* Defender);
+	void TargetAttack(Character* Attacker, Monster* Defender);
+
 private:
     Character* BattlePlayer;
     Monster* BattleMonster;

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -1,5 +1,15 @@
 ﻿#pragma once
 
+namespace
+{
+	enum EBattleTurn
+	{
+		PlayerTurn,
+		MonsterTurn,
+		End,
+	};
+};
+
 class Monster;
 class BossMonster;
 class Character;
@@ -25,10 +35,15 @@ private:
 	void InitBattle(Character* Player);
 	void StartBattle();
 	void EndBattle();
+	void PlayTurn();
+	void SaveTurn();
+	void NextTurn();
 
 	Monster* CreateBattleMonster(int PlayerLevel);
 
 private:
     Character* BattlePlayer;
     Monster* BattleMonster;
+
+	EBattleTurn BattleTurn;
 };

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -61,6 +61,9 @@ private:
 	void TargetAttack(Monster* Attacker, Character* Defender);
 	void TargetAttack(Character* Attacker, Monster* Defender);
 
+	void DisplayBattleInfos();
+	void DisplayBattleInfo(const FBattleTurnInfo& PrevInfo, const FBattleTurnInfo& CurInfo, int TurnIdx);
+
 private:
     Character* BattlePlayer;
     Monster* BattleMonster;

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -3,6 +3,12 @@
 
 namespace
 {
+	enum EBattleResult
+	{
+		PlayerWin,
+		MonsterWin, 
+	};
+
 	enum EBattleTurn
 	{
 		PlayerTurn,
@@ -60,5 +66,6 @@ private:
     Monster* BattleMonster;
 
 	EBattleTurn BattleTurn;
+	EBattleResult BattleResult;
 	std::vector<FBattleTurnInfo> BattleTurnInfos;
 };

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -1,8 +1,21 @@
 ﻿#pragma once
 #include <vector>
 
+class Monster;
+class BossMonster;
+class Character;
+class Item;
+
 namespace
 {
+	#define ITEM_DROP_CHANCE 30
+
+	enum EPotionType
+	{
+		ITEM_IDX_HEALTHPOTION,
+		ITEM_IDX_ATTACKBOOST,
+	};
+
 	enum EBattleResult
 	{
 		PlayerWin,
@@ -24,11 +37,14 @@ namespace
 		int PlayerAttack;
 		EBattleTurn BattleTurn;
 	};
-}
 
-class Monster;
-class BossMonster;
-class Character;
+	struct FBattleReward
+	{
+		int Experience;
+		int Gold;
+		Item* Item;
+	};
+}
 
 class GameManager
 {
@@ -54,6 +70,8 @@ private:
 	void PlayTurn();
 	void SaveTurn();
 	void NextTurn();
+	void ReceiveBattleReward();
+	void TryTakePotion(Item* RewardItem, EPotionType PostionType);
 
 	Monster* CreateBattleMonster(int PlayerLevel);
 
@@ -63,6 +81,7 @@ private:
 
 	void DisplayBattleInfos();
 	void DisplayBattleInfo(const FBattleTurnInfo& PrevInfo, const FBattleTurnInfo& CurInfo, int TurnIdx);
+	void DisplayBattleResult();
 
 private:
     Character* BattlePlayer;
@@ -70,5 +89,6 @@ private:
 
 	EBattleTurn BattleTurn;
 	EBattleResult BattleResult;
+	FBattleReward BattleReward;
 	std::vector<FBattleTurnInfo> BattleTurnInfos;
 };

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -19,4 +19,10 @@ public:
 
 private:
     void Init();
+
+/* 전투 관련 */
+	bool CanBattle();
+	void InitBattle(Character* Player);
+	void StartBattle();
+	void EndBattle();
 };

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -1,5 +1,4 @@
 ﻿#pragma once
-
 namespace
 {
 	enum EBattleTurn

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -25,4 +25,10 @@ private:
 	void InitBattle(Character* Player);
 	void StartBattle();
 	void EndBattle();
+
+	Monster* CreateBattleMonster(int PlayerLevel);
+
+private:
+    Character* BattlePlayer;
+    Monster* BattleMonster;
 };

--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -1,4 +1,6 @@
 ﻿#pragma once
+#include <vector>
+
 namespace
 {
 	enum EBattleTurn
@@ -7,7 +9,16 @@ namespace
 		MonsterTurn,
 		End,
 	};
-};
+
+	struct FBattleTurnInfo
+	{
+		int MonsterHP;
+		int MonsterAttack;
+		int PlayerHP;
+		int PlayerAttack;
+		EBattleTurn BattleTurn;
+	};
+}
 
 class Monster;
 class BossMonster;
@@ -49,4 +60,5 @@ private:
     Monster* BattleMonster;
 
 	EBattleTurn BattleTurn;
+	std::vector<FBattleTurnInfo> BattleTurnInfos;
 };


### PR DESCRIPTION
@hyounjinJoo 
@jihanchoi 
@Vetenir 
@gwo1004 

[기능 설명]
배틀은 총 4가지로 나뉘어 작동합니다.
- 배틀 초기화 (InitBattle) : 배틀 시작전 필요한 데이터를 초기화합니다.
- 배틀 가능 확인 (CanBattle) : 현재 배틀이 가능한지 확인합니다.
- 배틀 시작 (StartBattle) : 각 턴 별로 플레이어와 몬스터가 자동 전투를 시작합니다.
- 배틀 종료 (EndBattle) : 배틀 종료 후 배틀 정보를 출력하고 보상을 획득합니다.

세부 구현 내용은 커밋 메시지 또는 주석으로 추가설명하였습니다.

![image](https://github.com/user-attachments/assets/0649e217-cb80-4ac8-9d3f-76e9ddac251e)

현재 남은 부분 (턴제 배틀에서)
- 전투중 랜덤한 포션 사용

