### PR TITLE
[🎉add] 전투 중 포션 사용 구현

### DIFF
--- a/Manager/GameManager.h
+++ b/Manager/GameManager.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include <vector>
+#include <string>
 
 class Monster;
 class BossMonster;
@@ -9,11 +10,13 @@ class Item;
 namespace
 {
 	#define ITEM_DROP_CHANCE 30
+	#define HEALTH_RECOVERY_THRESHOLD 40
 
 	enum EPotionType
 	{
 		ITEM_IDX_HEALTHPOTION,
 		ITEM_IDX_ATTACKBOOST,
+		NONE,
 	};
 
 	enum EBattleResult
@@ -35,6 +38,9 @@ namespace
 		int MonsterAttack;
 		int PlayerHP;
 		int PlayerAttack;
+		EPotionType UsePotionType;
+		std::string UseItemName;
+		std::string UseItemDescription;
 		EBattleTurn BattleTurn;
 	};
 
@@ -67,6 +73,7 @@ private:
 	void InitBattle(Character* Player);
 	void StartBattle();
 	void EndBattle();
+	void InitTurn();
 	void PlayTurn();
 	void SaveTurn();
 	void NextTurn();
@@ -76,6 +83,7 @@ private:
 	Monster* CreateBattleMonster(int PlayerLevel);
 
 	void TryUsePotion();
+	void UsePotion(std::vector<Item*>& Inventory, EPotionType UsePotionType);
 	void TargetAttack(Monster* Attacker, Character* Defender);
 	void TargetAttack(Character* Attacker, Monster* Defender);
 
@@ -91,4 +99,5 @@ private:
 	EBattleResult BattleResult;
 	FBattleReward BattleReward;
 	std::vector<FBattleTurnInfo> BattleTurnInfos;
+	FBattleTurnInfo CurTurnInfo;
 };


### PR DESCRIPTION
@hyounjinJoo
@gwo1004

[참고]
![image](https://github.com/user-attachments/assets/542ba696-9e80-44ed-a653-bb5e2b429ccd)
아스가르드 - 자동포션 체력이 몇 퍼센트 이하로 떨어졌을 때 포션을 사용한다.

[포션 사용]
- 포션은 플레이어 턴에 사용합니다.
- 포션은 한 턴에 한 번 사용을 시도합니다.
- 헬스 포션은 체력이 40% 미만으로 떨어질 경우 사용합니다.
- 어택 부스트 포션은 인벤토리에 유효할 경우 사용합니다.

[화면 출력]
- 포션 사용시 화면 출력을 위해 사용한 포션 데이터를 저장합니다.
- 턴 시작시 이전 턴 데이터를 초기화합니다.